### PR TITLE
Add `forecastvar` and `histvar` and minor changes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ LocalProjections = "0.2"
 MatrixEquations = "2"
 Roots = "1, 2"
 StatsAPI = "1.2"
-StatsBase = "0.33"
+StatsBase = "0.33, 0.34"
 Tables = "1"
 julia = "1.3"
 

--- a/src/AutoregressiveModels.jl
+++ b/src/AutoregressiveModels.jl
@@ -2,20 +2,20 @@ module AutoregressiveModels
 
 using Base: ReshapedArray
 using LinearAlgebra: Cholesky, cholesky!, cholesky, UpperTriangular, LowerTriangular,
-    lu!, ldiv!, rdiv!, inv!, mul!, diagm, eigen!, eigen, I, dot
+    lu!, ldiv!, rdiv!, inv!, mul!, diagm, eigen!, eigen, I
 using MatrixEquations: lyapd
 using Random: randn!
 using Roots: find_zero, Brent
-using StatsAPI: StatisticalModel, RegressionModel
+using StatsAPI: RegressionModel
 using StatsBase: sample
 using Tables
 using Tables: getcolumn
 
 import Base: show
-import StatsAPI: coef, modelmatrix, residuals, dof_residual, fit
+import StatsAPI: response, modelmatrix, coef, residuals, dof_residual, fit
 
 # Reexport objects from StatsAPI
-export coef, modelmatrix, residuals, dof_residual, fit
+export response, modelmatrix, coef, residuals, dof_residual, fit
 
 export VARProcess,
        nvar,
@@ -28,8 +28,13 @@ export VARProcess,
        simulate,
        impulse!,
        impulse,
+       forecastvar!,
+       forecastvar,
+       histvar!,
+       histvar,
 
        OLS,
+       intercept,
        coefcorrected,
        residvcov,
        residchol,

--- a/src/bootstrap.jl
+++ b/src/bootstrap.jl
@@ -39,6 +39,7 @@ end
 # An unsafe version for bootstrap
 function _fitvar!(data::Matrix, m::OLS, nlag, nocons)
     i0 = nocons ? 0 : 1
+    # Y in OLS is left untouched but use resid in-place
     Y = residuals(m)
     X = modelmatrix(m)
     N = size(Y, 2)

--- a/test/estimation.jl
+++ b/test/estimation.jl
@@ -27,10 +27,12 @@
               0.19390"""
     end
 
+    @test size(response(r)) == (258, 5)
     @test coef(r) == coef(ols)
     @test coef(r, 2, 2) == coef(ols)[3,2]
     @test coef(r, :ff, :logcpi, 3) == coef(ols)[12,3]
     @test coef(r, 2, :constant) == coef(ols)[1,2]
+    @test intercept(r) == coef(r)[1,:]
     @test residvcov(r) == residvcov(ols)
     @test residvcov(r, 1) == residvcov(ols)[1]
     @test residvcov(r, :logip, 3) == residvcov(ols)[2,3]

--- a/test/estimation.jl
+++ b/test/estimation.jl
@@ -7,6 +7,7 @@
     @test maorder(r) == 0
     @test hasintercept(r)
     ols = r.est
+    @test size(response(ols)) == (258, 5)
     @test size(modelmatrix(ols)) == (258, 61)
     @test size(coef(ols)) == (61, 5)
     @test size(residuals(ols)) == (258, 5)
@@ -115,4 +116,12 @@
     impulse!(irf2, r1, 3:-1:2, choleskyshock=true)
     @test irf2 ≈ irf
     @test impulse(r1, 3:-1:2, 13, choleskyshock=true) ≈ irf
+
+    sirf = impulse(r1, 1:4, 13, choleskyshock=true)
+    fev = forecastvar(sirf)
+    @test fev ≈ cumsum(sirf.^2, dims=2)
+
+    shocks = residuals(r1) / residchol(r1)'
+    hv = histvar(sirf, shocks)
+    @test sum(view(hv,:,1,:)) ≈ sum(residuals(r1)[1,:])
 end


### PR DESCRIPTION
Add two helper methods that can be useful for forecast error variance decompositions and historical decompositions.